### PR TITLE
fix: Correct number of published likelihoods

### DIFF
--- a/book/SerializationAndPatching.ipynb
+++ b/book/SerializationAndPatching.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As of this tutorial, ATLAS has published 4 full likelihoods to HEPData\n",
+    "As of this tutorial, ATLAS has [published 5 full likelihoods to HEPData](https://pyhf.readthedocs.io/en/v0.6.0/citations.html#published-likelihoods)\n",
     "\n",
     "<p align=\"center\">\n",
     "<a href=\"https://www.hepdata.net/record/ins1755298?version=3\"><img src=\"https://raw.githubusercontent.com/matthewfeickert/talk-SciPy-2020/e0c509cd0dfef98f5876071edd4c60aff9199a1b/figures/HEPData_likelihoods.png\"></a>\n",


### PR DESCRIPTION
```
* Correct the number of published likelihoods to 5
   - c.f. https://pyhf.readthedocs.io/en/v0.6.0/citations.html#published-likelihoods
```